### PR TITLE
Fix DNU error in Pharo 10

### DIFF
--- a/src/Seaside-Plotly-Examples/WAPlotlyExamples.class.st
+++ b/src/Seaside-Plotly-Examples/WAPlotlyExamples.class.st
@@ -13,11 +13,9 @@ WAPlotlyExamples class >> initialize [
 
 { #category : #'rendering-meta' }
 WAPlotlyExamples >> examples [
-	^ OrderedCollection
-		streamContents: [ :s | 
-			Pragma
-				withPragmasIn: self class
-				do: [ :pragma | s nextPut: pragma method selector ] ]
+	^ OrderedCollection streamContents: [ :s | 
+		(Pragma allNamed: #example in: self class) do: [ :pragma | 
+			s nextPut: pragma method selector ] ]
 ]
 
 { #category : #private }


### PR DESCRIPTION
I ran into an error when trying to load the examples in Pharo 10. Looks like `Pragma>> withPragmasIn:` no longer exists. I replaced it with `Pragma>>Pragma allNamed: in:`.